### PR TITLE
Fix inconsistent include path in VCE and HEVC

### DIFF
--- a/amf/public/include/components/VideoEncoderHEVC.h
+++ b/amf/public/include/components/VideoEncoderHEVC.h
@@ -24,7 +24,7 @@
 #define __AMFVideoEncoderHW_HEVC_h__
 #pragma once
 
-#include "public/include/components/Component.h"
+#include "Component.h"
 
 #define AMFVideoEncoder_HEVC L"AMFVideoEncoderHW_HEVC"
 


### PR DESCRIPTION
For some reason HEVC includes public/include/components/Component.h instead of directly including Component.h. This fixes that.