### PR TITLE
fix for malformed files opening

### DIFF
--- a/amf/public/common/AMFSTL.cpp
+++ b/amf/public/common/AMFSTL.cpp
@@ -264,7 +264,7 @@ amf_string AMF_STD_CALL amf::amf_from_unicode_to_multibyte(const amf_wstring& st
 */
 #else
     amf_size Utf8BuffSize = wcstombs(NULL, pwBuff, 0);
-    if(0 == Utf8BuffSize)
+    if(static_cast<std::size_t>(-1) == Utf8BuffSize)
     {
         return result;
     }

--- a/amf/public/src/components/ComponentsFFMPEG/FileDemuxerFFMPEGImpl.cpp
+++ b/amf/public/src/components/ComponentsFFMPEG/FileDemuxerFFMPEGImpl.cpp
@@ -489,7 +489,7 @@ AMF_RESULT AMF_STD_CALL  AMFFileDemuxerFFMPEGImpl::Init(AMF_SURFACE_FORMAT /*for
         ReadRangeSettings();
     }
 
-    return AMF_OK;
+    return res;
 }
 //-------------------------------------------------------------------------------------------------
 AMF_RESULT AMF_STD_CALL  AMFFileDemuxerFFMPEGImpl::ReInit(amf_int32 width, amf_int32 height)


### PR DESCRIPTION
AMFSTL.cpp:267 - correcly handle wcstombs return code to check invalid results

FileDemuxerFFMPEGImpl.cpp:492 - return AMF_RESULT from Open() call, becouse Init() callers demands actual open result, this will fix crushes after malformed file opening