### PR TITLE
Use __declspec(selectany) on any windows compiler, not only MSVC

### DIFF
--- a/amf/public/include/core/Platform.h
+++ b/amf/public/include/core/Platform.h
@@ -131,7 +131,7 @@
 #endif // WIN32
 
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 #define AMF_WEAK __declspec( selectany ) 
 #elif defined (__GNUC__) || defined (__GCC__) || defined(__clang__)//GCC or CLANG
 #define AMF_WEAK __attribute__((weak))


### PR DESCRIPTION
GCC and Clang (in MinGW mode) also do support `__declspec(selectany)`, and using `__declspec(selectany)` instead of `__attribute__((weak))` on Windows avoids including the data multiple times in the linked image. (`__attribute__((weak))`, on COFF at least, only avoids a conflict for multiple definitions but doesn't deduplicate the content, like `__declspec(selectany)` does.)

This avoids the fact that Clang doesn't fully implement `__attribute__((weak))` on Windows yet.