### PR TITLE
Fix missing include

### DIFF
--- a/amf/public/include/components/ColorSpace.h
+++ b/amf/public/include/components/ColorSpace.h
@@ -37,6 +37,8 @@
 #define AMF_ColorSpace_h
 #pragma once
 
+#include "../core/Platform.h"
+
 // YUV <--> RGB conversion matrix with range
 typedef enum AMF_VIDEO_CONVERTER_COLOR_PROFILE_ENUM
 {


### PR DESCRIPTION
This header uses types like amf_uint16 but does not include their definition.