### PR TITLE
Platform.h: tie typedef for HRESULT to !windows

### DIFF
--- a/amf/public/include/core/Platform.h
+++ b/amf/public/include/core/Platform.h
@@ -72,7 +72,7 @@
 //     #error Need to define AMF_ALIGN
  #endif
 
-#if defined(__linux) || (__clang__)
+#if !defined(_WIN32)
 typedef signed int HRESULT;
 #define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
 #define FAILED(hr) (((HRESULT)(hr)) < 0)


### PR DESCRIPTION
The existence of `__clang__` there breaks clang on Windows compilation
due to conflicting LONG vs INT typedefs

same thing with the SUCCESS and FAILED macros