### PR TITLE
Don't cast amf_int64 when using a format string

### DIFF
--- a/amf/public/include/core/Platform.h
+++ b/amf/public/include/core/Platform.h
@@ -127,7 +127,16 @@ typedef signed int HRESULT;
 #endif
     #define AMF_NO_VTABLE
 
-    #if !defined(AMFPRId64)
+    #if defined(__x86_64__) || defined(__aarch64__)
+        #define AMFPRId64    "ld"
+        #define LPRId64     L"ld"
+
+        #define AMFPRIud64    "uld"
+        #define LPRIud64     L"uld"
+
+        #define AMFPRIx64    "lx"
+        #define LPRIx64     L"lx"
+    #else
         #define AMFPRId64    "lld"
         #define LPRId64     L"lld"
 

--- a/amf/public/include/core/Variant.h
+++ b/amf/public/include/core/Variant.h
@@ -872,14 +872,14 @@ namespace amf
     {
         res = AMF_OK;
         char buff[0xFF];
-        sprintf(buff, "%" AMFPRId64, (long long)value);
+        sprintf(buff, "%" AMFPRId64, value);
         return buff;
     }
     static AMF_INLINE AMFVariant::WString AMFConvertInt64ToWString(amf_int64 value, AMF_RESULT& res)
     {
         res = AMF_OK;
         wchar_t buff[0xFF];
-        swprintf(buff, 0xFF, L"%" LPRId64, (long long)value);
+        swprintf(buff, 0xFF, L"%" LPRId64, value);
         return buff;
     }
 


### PR DESCRIPTION
The format string is designed to match amf_int64.