### PR TITLE
Publish headers bundle when releasing new version

### DIFF
--- a/.github/workflows/publish-header.yml
+++ b/.github/workflows/publish-header.yml
@@ -1,0 +1,20 @@
+name: Publish Header
+
+on:
+  push: 
+    tags: v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: bundle header
+      run: |
+        mv amf/public/include AMF
+        tar czf AMF-headers.tar.gz AMF/
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: AMF-headers.tar.gz


### PR DESCRIPTION
When building ffmpeg or other software that requires AMF headers, cloning full repo is really slow because of a lot of binary data.

By using github action to bundle the headers, users can only download the tar file which only 76kb. 

Demo release: https://github.com/abihf/AMF/releases/tag/v1.4.33