### PR TITLE
Include root directory that matches file name

### DIFF
--- a/.github/workflows/publish-header.yml
+++ b/.github/workflows/publish-header.yml
@@ -11,8 +11,9 @@ jobs:
     - uses: actions/checkout@v3
     - name: bundle header
       run: |
-        mv amf/public/include AMF
-        tar czf AMF-headers.tar.gz AMF/
+        mkdir amf-headers
+        mv amf/public/include amf-headers/AMF
+        tar czf AMF-headers.tar.gz amf-headers/
     - name: Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/publish-header.yml
+++ b/.github/workflows/publish-header.yml
@@ -1,7 +1,7 @@
 name: Publish Header
 
 on:
-  push: 
+  push:
     tags: v*
 
 jobs:
@@ -11,11 +11,11 @@ jobs:
     - uses: actions/checkout@v3
     - name: bundle header
       run: |
-        mkdir amf-headers
-        mv amf/public/include amf-headers/AMF
-        tar czf AMF-headers.tar.gz amf-headers/
+        mkdir amf-headers-${{ github.ref_name }
+        mv amf/public/include amf-headers-${{ github.ref_name }}/AMF
+        tar czf AMF-headers.tar.gz amf-headers-${{ github.ref_name }}/
     - name: Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        files: AMF-headers.tar.gz
+        files: AMF-headers-${{ github.ref_name }}.tar.gz


### PR DESCRIPTION
Github's generated release files include the root directory when publishing releases. Make sure this action also has this characteristic.

In other repositories where the release tarfile is created by Github, the root directory of the project is included. See https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/archive/refs/tags/v3.1.0.tar.gz for an example of this.