### PR TITLE
match ffmpeg SDK location

### DIFF
--- a/amf/public/src/components/ComponentsFFMPEG/Makefile
+++ b/amf/public/src/components/ComponentsFFMPEG/Makefile
@@ -37,7 +37,6 @@ uname_p := $(shell uname -p)
   platform_name=lnx
 endif
 
-ffmpeg_dir = $(amf_root)/../Thirdparty/ffmpeg/ffmpeg/ffmpeg-7.0/$(platform_name)$(host_bits)/release
 
 pp_defines += \
   AMF_COMPONENT_FFMPEG_EXPORTS

--- a/amf/public/src/components/ComponentsFFMPEG/Makefile
+++ b/amf/public/src/components/ComponentsFFMPEG/Makefile
@@ -37,7 +37,7 @@ uname_p := $(shell uname -p)
   platform_name=lnx
 endif
 
-ffmpeg_dir = $(amf_root)/../Thirdparty/ffmpeg/ffmpeg/ffmpeg-6.0/$(platform_name)$(host_bits)/release
+ffmpeg_dir = $(amf_root)/../Thirdparty/ffmpeg/ffmpeg/ffmpeg-7.0/$(platform_name)$(host_bits)/release
 
 pp_defines += \
   AMF_COMPONENT_FFMPEG_EXPORTS


### PR DESCRIPTION
The SDK now ships with version 7 of ffmpeg:
`AMF/tree/master/Thirdparty/ffmpeg/ffmpeg/ffmpeg-7.0`