### PR TITLE
add `static` to fix errors when an inline function is used in multipl…

### DIFF
--- a/amf/public/include/core/AudioBuffer.h
+++ b/amf/public/include/core/AudioBuffer.h
@@ -85,7 +85,7 @@ namespace amf
     } AMF_AUDIO_CHANNEL_LAYOUT;
 
     // get the most common layout for a given number of speakers
-    inline int GetDefaultChannelLayout(int channels)
+    static inline int GetDefaultChannelLayout(int channels)
     {
         switch (channels)
         {


### PR DESCRIPTION
…e files

see https://bugs.gentoo.org/834761, build is failed for media-tv/mythtv due to multiple definitions of 'GetDefaultChannelLayout'